### PR TITLE
Add option to export to txt file.

### DIFF
--- a/src/BCA/LaravelInspect/Commands/Inspect.php
+++ b/src/BCA/LaravelInspect/Commands/Inspect.php
@@ -102,6 +102,14 @@ abstract class Inspect extends Command
             'app'
         );
 
+        $options[] = array(
+          'export',
+          'e',
+          InputOption::VALUE_OPTIONAL,
+          'Export report to txt file.',
+          'phpmd-analysis.txt'
+        );
+
         // Offer to install the ruleset locally if available.
         $this->setPaths();
         if ($this->pathRulesetStock !== null) {

--- a/src/BCA/LaravelInspect/Commands/InspectMessCommand.php
+++ b/src/BCA/LaravelInspect/Commands/InspectMessCommand.php
@@ -76,8 +76,11 @@ class InspectMessCommand extends Inspect
         $command = $this->pathCli.' ';
         $command.= base_path().'/'.$this->option('path').' ';
         $command.= 'text ';
+        if($this->option('export')){
+          $command.= '--reportfile ' . $this->option('export') . ' ';
+        }
         $command.= $this->pathRuleset;
-
+        $this->info($command);
         passthru($command, $exitCode);
 
         $this->info('Done.');


### PR DESCRIPTION
Added option to export phpmd to txt file. Use option `--export=<TEXT_NAME>` or  `-e=<TEXT_NAME>`. Value is optional.
